### PR TITLE
Expanding list of OSes the svn gem is broken on

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This software needs to be available for the user that hosts the repository.
 
         gem install svn multi_json --no-ri --no-rdoc
 
-  NOTE: The current version of the svn gem (0.2.0) is broken on Mac OS X. You need to
+  NOTE: The current version of the svn gem (0.2.0) is broken on some operating
+  systems including Mac OS X and RedHat Enterprise Linux/CentOS. You need to
   install the gem manually from Github sources.
 
 ### Install


### PR DESCRIPTION
It seems that Debian based operating systems set the `SOVERSION` to 1 for svn libraries, however the default used by subversion is 0. This causes systems using the default to fail, which also includes RHEL/CentOS. It's been fixed in the master branch of the gem, but the fix isn't released yet.